### PR TITLE
Update ubuntu golang installaction

### DIFF
--- a/cookbooks/go/default.rb
+++ b/cookbooks/go/default.rb
@@ -1,4 +1,13 @@
-package 'golang'
+if node[:platform] == 'darwin'
+  package 'golang'
+elsif node[:platform] == 'ubuntu'
+  execute "install go" do
+    command "
+      curl -LO https://go.dev/dl/go1.18beta1.linux-amd64.tar.gz
+      tar -C /usr/local -xzf go1.18beta1.linux-amd64.tar.gz
+    "
+  end
+end
 
 gopath = "#{ENV['HOME']}"
 gobin = "#{ENV['HOME']}/gobin"


### PR DESCRIPTION
## Why

Because the version of go apt installs is older.

```
current: 1.13
ideal: 1.18
```

## What
Update way I installed ubuntu go
